### PR TITLE
Incompatible function pointer types

### DIFF
--- a/docObj.c
+++ b/docObj.c
@@ -1852,9 +1852,7 @@ ErrorCodeToString(code)
 }
 
 void
-TclXML_libxml2_ErrorHandler (ctx, error)
-     void *ctx; /* ignore - depends on context */
-     xmlErrorPtr error;
+TclXML_libxml2_ErrorHandler (void *ctx, const xmlError *error)
 {
   ThreadSpecificData *tsdPtr = Tcl_GetThreadData(&dataKey, sizeof(ThreadSpecificData));
   Tcl_Obj *objPtr;

--- a/include/tclxml-libxml2/tclxml-libxml2Decls.h
+++ b/include/tclxml-libxml2/tclxml-libxml2Decls.h
@@ -55,7 +55,7 @@ EXTERN void		TclXML_libxml2_DocKeep _ANSI_ARGS_((Tcl_Obj * objPtr,
 				TclXML_libxml2_DocumentHandling keep));
 /* 10 */
 EXTERN void		TclXML_libxml2_ErrorHandler _ANSI_ARGS_((void * ctx, 
-				xmlErrorPtr error));
+				const xmlError *error));
 /* 11 */
 EXTERN void		TclXML_libxml2_ResetError _ANSI_ARGS_((
 				Tcl_Interp * interp));


### PR DESCRIPTION
This fix the gcc warning -Wincompatible-pointer-types
and allow building with clang-17